### PR TITLE
test: VRTワークフローのテスト（web・uiの変更）

### DIFF
--- a/.github/workflows/visual-regression-test.yaml
+++ b/.github/workflows/visual-regression-test.yaml
@@ -388,7 +388,7 @@ jobs:
 
       - name: Set up reg-suit expected and actual directories
         run: |
-          mkdir -p __screenshots__ __expected__
+          mkdir -p __screenshots__ .reg/expected
           if [ -d artifacts-pr/ui/__snapshots__ ]; then
             cp -R artifacts-pr/ui/__snapshots__ __screenshots__/ui
           fi
@@ -396,10 +396,10 @@ jobs:
             cp -R artifacts-pr/web/__snapshots__ __screenshots__/web
           fi
           if [ -d artifacts-base/ui/__snapshots__ ]; then
-            cp -R artifacts-base/ui/__snapshots__ __expected__/ui
+            cp -R artifacts-base/ui/__snapshots__ .reg/expected/ui
           fi
           if [ -d artifacts-base/web/__snapshots__ ]; then
-            cp -R artifacts-base/web/__snapshots__ __expected__/web
+            cp -R artifacts-base/web/__snapshots__ .reg/expected/web
           fi
 
       - name: run reg-suit

--- a/.github/workflows/visual-regression-test.yaml
+++ b/.github/workflows/visual-regression-test.yaml
@@ -367,7 +367,7 @@ jobs:
       - name: set up repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up node_modules
         uses: ./.github/actions/setup-node

--- a/.github/workflows/visual-regression-test.yaml
+++ b/.github/workflows/visual-regression-test.yaml
@@ -367,7 +367,7 @@ jobs:
       - name: set up repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Set up node_modules
         uses: ./.github/actions/setup-node

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "lerna": "^6.6.2",
     "prettier": "2.8.7",
     "prettier-plugin-tailwindcss": "^0.3.0",
+    "reg-local-publisher-plugin": "workspace:*",
     "reg-notify-github-plugin": "^0.12.1",
     "reg-suit": "0.12.1",
     "rimraf": "^5.0.0",

--- a/packages/ui/components/Button/Button.tsx
+++ b/packages/ui/components/Button/Button.tsx
@@ -12,7 +12,7 @@ export const Button: React.FC<ButtonProps> = ({ variant, isLoading, disabled, ch
   return (
     <button
       {...props}
-      className={`mx-auto max-w-3xl text-white ${backgroundColor[variant]} disabled:bg-tertiary rounded px-4 py-2`}
+      className={`mx-auto max-w-3xl text-white ${backgroundColor[variant]} disabled:bg-tertiary rounded-full px-4 py-2`}
       disabled={disabled || isLoading}
     >
       {isLoading ? <span className="material-symbols-outlined animate-rotate">refresh</span> : children}

--- a/packages/ui/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/ui/components/Button/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`components/Button > components/Button > "Default" story > renders without crashing 1`] = `
 <div>
   <button
-    class="mx-auto max-w-3xl text-white bg-primary disabled:bg-tertiary rounded px-4 py-2"
+    class="mx-auto max-w-3xl text-white bg-primary disabled:bg-tertiary rounded-full px-4 py-2"
   >
     Button
   </button>

--- a/packages/web/src/presentation/edit/EditView/__snapshots__/EditView.test.tsx.snap
+++ b/packages/web/src/presentation/edit/EditView/__snapshots__/EditView.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`views/EditView > views/EditView > "Default" story > renders without cra
       </div>
     </label>
     <button
-      class="mx-auto max-w-3xl text-white bg-primary disabled:bg-tertiary rounded px-4 py-2"
+      class="mx-auto max-w-3xl text-white bg-primary disabled:bg-tertiary rounded-full px-4 py-2"
       type="submit"
     >
       登録
@@ -176,7 +176,7 @@ exports[`views/EditView > views/EditView > "Loading" story > renders without cra
       </div>
     </label>
     <button
-      class="mx-auto max-w-3xl text-white bg-primary disabled:bg-tertiary rounded px-4 py-2"
+      class="mx-auto max-w-3xl text-white bg-primary disabled:bg-tertiary rounded-full px-4 py-2"
       disabled=""
       type="submit"
     >

--- a/packages/web/src/presentation/home/HomeView/HomeView.tsx
+++ b/packages/web/src/presentation/home/HomeView/HomeView.tsx
@@ -16,7 +16,7 @@ export const HomeView = ({ isLoading, todos }: HomeViewProps) => {
   return (
     <>
       <LinkButton href="/register" variant="primary">
-        登録
+        新規登録
       </LinkButton>
       <div className="mt-4">
         {todos?.map((todo) => (

--- a/packages/web/src/presentation/home/HomeView/__snapshots__/HomeView.test.tsx.snap
+++ b/packages/web/src/presentation/home/HomeView/__snapshots__/HomeView.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`views/HomeView > views/HomeView > "Default" story > renders without cra
     class="mx-auto max-w-3xl text-white bg-primary rounded px-4 py-2"
     href="/register"
   >
-    登録
+    新規登録
   </a>
   <div
     class="mt-4"

--- a/packages/web/src/presentation/register/RegisterView/__snapshots__/RegisterView.test.tsx.snap
+++ b/packages/web/src/presentation/register/RegisterView/__snapshots__/RegisterView.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`views/RegisterView > views/RegisterView > "Default" story > renders wit
       </fieldset>
     </div>
     <button
-      class="mx-auto max-w-3xl text-white bg-primary disabled:bg-tertiary rounded px-4 py-2"
+      class="mx-auto max-w-3xl text-white bg-primary disabled:bg-tertiary rounded-full px-4 py-2"
       data-testid="register-button"
       type="submit"
     >
@@ -144,7 +144,7 @@ exports[`views/RegisterView > views/RegisterView > "Loading" story > renders wit
       </fieldset>
     </div>
     <button
-      class="mx-auto max-w-3xl text-white bg-primary disabled:bg-tertiary rounded px-4 py-2"
+      class="mx-auto max-w-3xl text-white bg-primary disabled:bg-tertiary rounded-full px-4 py-2"
       data-testid="register-button"
       disabled=""
       type="submit"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.3.0
         version: 0.3.0(prettier@2.8.7)
+      reg-local-publisher-plugin:
+        specifier: workspace:*
+        version: link:tools/reg-local-publisher-plugin
       reg-notify-github-plugin:
         specifier: ^0.12.1
         version: 0.12.2
@@ -351,6 +354,8 @@ importers:
       orval:
         specifier: ^6.14.4
         version: 6.31.0(encoding@0.1.13)(openapi-types@12.1.3)(typescript@5.9.3)
+
+  tools/reg-local-publisher-plugin: {}
 
 packages:
 

--- a/regconfig.json
+++ b/regconfig.json
@@ -13,6 +13,7 @@
       "expectedKey": "expected",
       "actualKey": "actual"
     },
+    "reg-local-publisher-plugin": {},
     "reg-notify-github-plugin": {
       "clientId": "${REG_NOTICE_CLIENT_ID}",
       "prComment": true,

--- a/regconfig.json
+++ b/regconfig.json
@@ -9,6 +9,10 @@
     }
   },
   "plugins": {
+    "reg-simple-keygen-plugin": {
+      "expectedKey": "expected",
+      "actualKey": "actual"
+    },
     "reg-notify-github-plugin": {
       "clientId": "${REG_NOTICE_CLIENT_ID}",
       "prComment": true,

--- a/regconfig.json
+++ b/regconfig.json
@@ -1,7 +1,7 @@
 {
   "core": {
     "actualDir": "./__screenshots__",
-    "expectedDir": "./__expected__",
+    "expectedDir": "./.reg/expected",
     "thresholdRate": 0,
     "addIgnore": false,
     "ximgdiff": {

--- a/tools/reg-local-publisher-plugin/package.json
+++ b/tools/reg-local-publisher-plugin/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "reg-local-publisher-plugin",
+  "version": "1.0.0",
+  "private": true,
+  "description": "A reg-suit publisher plugin that uses pre-placed local files instead of remote storage",
+  "main": "src/index.js",
+  "license": "MIT"
+}

--- a/tools/reg-local-publisher-plugin/src/index.js
+++ b/tools/reg-local-publisher-plugin/src/index.js
@@ -35,9 +35,7 @@ class LocalPublisherPlugin {
   fetch(_key) {
     const { expectedDir } = this._workingDirs;
     if (!fs.existsSync(expectedDir)) {
-      return Promise.reject(
-        new Error(`[reg-local-publisher-plugin] expectedDir was not found: ${expectedDir}`),
-      );
+      return Promise.reject(new Error(`[reg-local-publisher-plugin] expectedDir was not found: ${expectedDir}`));
     }
     this._logger.info(`[reg-local-publisher-plugin] Using pre-placed files in ${expectedDir}`);
     return Promise.resolve();

--- a/tools/reg-local-publisher-plugin/src/index.js
+++ b/tools/reg-local-publisher-plugin/src/index.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const fs = require("node:fs");
+
 /**
  * reg-local-publisher-plugin
  *
@@ -31,7 +33,13 @@ class LocalPublisherPlugin {
    * so nothing to do.
    */
   fetch(_key) {
-    this._logger.info(`[reg-local-publisher-plugin] Using pre-placed files in ${this._workingDirs.expectedDir}`);
+    const { expectedDir } = this._workingDirs;
+    if (!fs.existsSync(expectedDir)) {
+      return Promise.reject(
+        new Error(`[reg-local-publisher-plugin] expectedDir was not found: ${expectedDir}`),
+      );
+    }
+    this._logger.info(`[reg-local-publisher-plugin] Using pre-placed files in ${expectedDir}`);
     return Promise.resolve();
   }
 

--- a/tools/reg-local-publisher-plugin/src/index.js
+++ b/tools/reg-local-publisher-plugin/src/index.js
@@ -1,0 +1,49 @@
+"use strict";
+
+/**
+ * reg-local-publisher-plugin
+ *
+ * A reg-suit publisher plugin that skips remote fetch/publish
+ * and uses pre-placed local files in workingDirs.expectedDir directly.
+ *
+ * Intended for CI environments where base branch screenshots are
+ * already placed in .reg/expected/ before reg-suit runs.
+ *
+ * Based on reg-publish-github-pages-plugin by Leko:
+ * https://github.com/Leko/reg-publish-github-pages-plugin
+ */
+
+class LocalPublisherPlugin {
+  constructor() {
+    this.name = "reg-local-publisher-plugin";
+  }
+
+  init(config) {
+    this._logger = config.logger;
+    this._workingDirs = config.workingDirs;
+    this._noEmit = config.noEmit;
+  }
+
+  /**
+   * fetch: expected files are already in workingDirs.expectedDir,
+   * so nothing to do.
+   */
+  fetch(_key) {
+    this._logger.info(`[reg-local-publisher-plugin] Using pre-placed files in ${this._workingDirs.expectedDir}`);
+    return Promise.resolve();
+  }
+
+  /**
+   * publish: no remote storage to push to, skip.
+   */
+  publish(_key) {
+    this._logger.info("[reg-local-publisher-plugin] Skipped publishing (local-only mode)");
+    return Promise.resolve({ reportUrl: "" });
+  }
+}
+
+const pluginFactory = () => ({
+  publisher: new LocalPublisherPlugin(),
+});
+
+module.exports = pluginFactory;

--- a/tools/reg-local-publisher-plugin/src/index.js
+++ b/tools/reg-local-publisher-plugin/src/index.js
@@ -22,6 +22,8 @@ class LocalPublisherPlugin {
     this._logger = config.logger;
     this._workingDirs = config.workingDirs;
     this._noEmit = config.noEmit;
+    // reportUrl can be set via plugin option or REPORT_URL env var
+    this._reportUrl = (config.options && config.options.reportUrl) || process.env.REPORT_URL || "";
   }
 
   /**
@@ -34,11 +36,16 @@ class LocalPublisherPlugin {
   }
 
   /**
-   * publish: no remote storage to push to, skip.
+   * publish: no remote storage to push to.
+   * Returns the GitHub Pages report URL so reg-notify-github-plugin
+   * can include it in the PR comment and commit status.
    */
   publish(_key) {
     this._logger.info("[reg-local-publisher-plugin] Skipped publishing (local-only mode)");
-    return Promise.resolve({ reportUrl: "" });
+    if (this._reportUrl) {
+      this._logger.info(`[reg-local-publisher-plugin] Report URL: ${this._reportUrl}`);
+    }
+    return Promise.resolve({ reportUrl: this._reportUrl });
   }
 }
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -6,6 +6,6 @@ export default defineConfig({
   test: {
     ...baseConfig.test,
     include: ["packages/**/*.{test,spec}.?(c|m)[jt]s?(x)"],
-    exclude: ["**/snapshot/*"],
+    exclude: ["**/node_modules/**", "**/snapshot/*"],
   },
 });


### PR DESCRIPTION
## Summary

- `packages/web`: HomeViewのボタンラベルを「登録」→「新規登録」に変更
- `packages/ui`: Buttonコンポーネントの角丸を `rounded` → `rounded-full` に変更

## Test plan

- [ ] `visual-regression-test` ワークフローが起動することを確認
- [ ] `web` パッケージのVRTでボタンラベルの差分が検出されることを確認
- [ ] `ui` パッケージのVRTでボタン形状の差分が検出されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **スタイル**
  * ボタンの角を完全な丸形に変更し、見た目を更新しました。
* **UI**
  * ホーム画面のボタンラベルを「登録」から「新規登録」に変更しました。
* **新機能**
  * ローカル専用のビジュアル差分パブリッシャープラグインを追加しました。
* **雑務**
  * ビジュアル検証のワークフローと期待アーティファクトの取り扱いを改善しました（設定・依存関係の追加を含む）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->