### PR TITLE
feat: lefthookでpre-commitにlint/formatの自動修正を設定

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,9 @@
+pre-commit:
+  parallel: true
+  commands:
+    lint:
+      glob: "*.{js,jsx,ts,tsx}"
+      run: pnpm exec eslint --fix {staged_files}
+    format:
+      glob: "*.{js,jsx,ts,tsx,md,html,json,yaml,yml}"
+      run: pnpm exec prettier --write {staged_files}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,9 +1,10 @@
 pre-commit:
-  parallel: true
   commands:
     lint:
-      glob: "*.{js,jsx,ts,tsx}"
+      glob: "**/*.{js,jsx,ts,tsx}"
       run: pnpm exec eslint --fix {staged_files}
+      stage_fixed: true
     format:
-      glob: "*.{js,jsx,ts,tsx,md,html,json,yaml,yml}"
+      glob: "**/*.{js,jsx,ts,tsx,md,html,json,yaml,yml}"
       run: pnpm exec prettier --write {staged_files}
+      stage_fixed: true

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "api": "pnpm --filter @demo/api",
     "format": "prettier '**/*.{js,jsx,ts,tsx,md,html,json,yaml,yml}' --write",
+    "prepare": "lefthook install",
     "formatcheck": "prettier '**/*.{js,jsx,ts,tsx,md,html,json,yaml,yml}' --check",
     "generate-api": "pnpm api generate",
     "lint": "pnpm lint-es && pnpm lint-css",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-storybook": "^0.6.15",
     "eslint-plugin-tailwindcss": "^3.12.0",
+    "lefthook": "^2.1.2",
     "lerna": "^6.6.2",
     "prettier": "2.8.7",
     "prettier-plugin-tailwindcss": "^0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       eslint-plugin-tailwindcss:
         specifier: ^3.12.0
         version: 3.18.2(tailwindcss@3.3.1(postcss@8.5.8))
+      lefthook:
+        specifier: ^2.1.2
+        version: 2.1.2
       lerna:
         specifier: ^6.6.2
         version: 6.6.2(@swc/core@1.15.18)(@types/node@18.19.130)(encoding@0.1.13)
@@ -7480,6 +7483,60 @@ packages:
   lazy-universal-dotenv@4.0.0:
     resolution: {integrity: sha512-aXpZJRnTkpK6gQ/z4nk+ZBLd/Qdp118cvPruLSIQzQNRhKwEcdXCOzXuF55VDqIiuAaY3UGZ10DJtvZzDcvsxg==}
     engines: {node: '>=14.0.0'}
+
+  lefthook-darwin-arm64@2.1.2:
+    resolution: {integrity: sha512-AgHu93YuJtj1l9bcKlCbo4Tg8N8xFl9iD6BjXCGaGMu46LSjFiXbJFlkUdpgrL8fIbwoCjJi5FNp3POpqs4Wdw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.2:
+    resolution: {integrity: sha512-exooc9Ectz13OLJJOXM9AzaFQbqzf9QCF8JuVvGfbr4RYABYK+BwwtydjlPQrA76/n/h4tsS11MH5bBULnLkYA==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.2:
+    resolution: {integrity: sha512-E1QMlJPEU21n9eewv6ePfh+JmoTSg5R1jaYcKCky10kfbMdohNucI3xV91F2LcerE+p3UejKDqr/1wWO2RMGeQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.2:
+    resolution: {integrity: sha512-/5zp+x8055Thj46x9S7hgnneZxvWhHQvPWkkgISCab1Lh6eLrbxvhE1qTb1lU3DqTnNmH9NeXdq1xPHc9uGluA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.2:
+    resolution: {integrity: sha512-UK5FvDTkwKO7tOznY8iEZzuTsM1jXMZAG5BMRs7olN1k1K6m2unR6oKABP0hCd0wDErK6DZKDJDJfB564Rzqtw==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.2:
+    resolution: {integrity: sha512-4eOtz4PNh8GbJ+nA8YVDfW/eMirQWdZqMP/V/MVtoVBGobf6oXvvuDOySvAPOgNYEFN0Boegytmuji/851Vstg==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.2:
+    resolution: {integrity: sha512-lJXRJ6iJIBKwomuNBA3CUNSclj2/rKuxGAQoUra214B92VB6jL9zaY5YEs6h/ie9jQrzSnllEeg7xyDIsuVCrQ==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.2:
+    resolution: {integrity: sha512-GyOje4W0DIqkmR7/Of5D+mZ0vWqMvtGAVedtJR6d1239xNeMzCS8Q+/a3O1xigceZa5xhlqq0BWlssB/QYPQnA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.2:
+    resolution: {integrity: sha512-MZKMqTULEpX/8N3fKXAR0A9RjsGKkEEY0japLqrHOIpxsJXry1DRz0FvQo2kkY4WW3rtFegV9m6eesOymuDrUg==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.2:
+    resolution: {integrity: sha512-NZUgObuaSxc0EXAwC/CzkMf7TuQc++GGIk6TLPdaUpoSsNSJSZEwBVz5DtFB1cG+eMkfO/wOKplls+yjimTTtQ==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.2:
+    resolution: {integrity: sha512-HdAMl4g47kbWSkrUkCx3Kucq54omFS6piMJtXwXNtmCAfB40UaybTJuYtFW4hNzZ5SvaEimtxTp7P/MNIkEfsA==}
+    hasBin: true
 
   lerna@6.6.2:
     resolution: {integrity: sha512-W4qrGhcdutkRdHEaDf9eqp7u4JvI+1TwFy5woX6OI8WPe4PYBdxuILAsvhp614fUG41rKSGDKlOh+AWzdSidTg==}
@@ -19148,6 +19205,49 @@ snapshots:
       app-root-dir: 1.0.2
       dotenv: 16.6.1
       dotenv-expand: 10.0.0
+
+  lefthook-darwin-arm64@2.1.2:
+    optional: true
+
+  lefthook-darwin-x64@2.1.2:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.2:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.2:
+    optional: true
+
+  lefthook-linux-arm64@2.1.2:
+    optional: true
+
+  lefthook-linux-x64@2.1.2:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.2:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.2:
+    optional: true
+
+  lefthook-windows-arm64@2.1.2:
+    optional: true
+
+  lefthook-windows-x64@2.1.2:
+    optional: true
+
+  lefthook@2.1.2:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.2
+      lefthook-darwin-x64: 2.1.2
+      lefthook-freebsd-arm64: 2.1.2
+      lefthook-freebsd-x64: 2.1.2
+      lefthook-linux-arm64: 2.1.2
+      lefthook-linux-x64: 2.1.2
+      lefthook-openbsd-arm64: 2.1.2
+      lefthook-openbsd-x64: 2.1.2
+      lefthook-windows-arm64: 2.1.2
+      lefthook-windows-x64: 2.1.2
 
   lerna@6.6.2(@swc/core@1.15.18)(@types/node@18.19.130)(encoding@0.1.13):
     dependencies:


### PR DESCRIPTION
## Summary

- lefthookをdevDependenciesに追加
- pre-commitフックでstaged filesに対してlint/formatを自動修正するよう設定
  - ESLint: `pnpm exec eslint --fix` (JS/TS ファイル対象)
  - Prettier: `pnpm exec prettier --write` (JS/TS/MD/HTML/JSON/YAML ファイル対象)
- staged filesのみを対象にすることで、coverageディレクトリ等の無関係なファイルへの誤実行を防止

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア（開発環境改善）**
  * Pre-commit フックによるコード品質チェックの自動実行環境を整備しました。JavaScriptやTypeScriptなどのファイルに対して、リント処理とコードフォーマッティングがコミット前に並行実行されるようになり、コード品質を統一的に保つことができます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->